### PR TITLE
Implemented the ignore mods functionality

### DIFF
--- a/xbanish.c
+++ b/xbanish.c
@@ -62,7 +62,7 @@ main(int argc, char *argv[])
 		{"mod4", Mod4Mask}, {"mod5", Mod5Mask}
 	};
 
-	while ((ch = getopt(argc, argv, "+di:")) != -1)
+	while ((ch = getopt(argc, argv, "di:")) != -1)
 		switch (ch) {
 		case 'i':
 			for (i = 0; i < sizeof(mods) / sizeof(struct mod_lookup); i++) {


### PR DESCRIPTION
This functionality was first described in #5.

Modifier keys to be ignored should be placed after a -i argument. For example:

xbanish -i Shift -i Mod4

Please let me know if there are any style changes I should make, I am rather new to C.
