### PR TITLE
xbanish.1: various improvements

### DIFF
--- a/xbanish.1
+++ b/xbanish.1
@@ -1,5 +1,5 @@
-.Dd $Mdocdate: July 21, 2014$
-.Dt xbanish 1
+.Dd $Mdocdate: June 10 2015$
+.Dt XBANISH 1
 .Os
 .Sh NAME
 .Nm xbanish
@@ -18,7 +18,7 @@ setting
 .Ic pointerMode
 but the effect is global in the X11 session.
 .Sh OPTIONS
-.Bl -tag
+.Bl -tag -width Ds
 .It Fl d
 Print debugging messages to stdout.
 .It Fl i Ar modifier
@@ -27,9 +27,8 @@ Ignore pressed key if
 is used.
 .El
 .Sh SEE ALSO
-.Xr xfixes 3
+.Xr XFixes 3
 .Sh AUTHORS
 .Nm
 was written by
-.An joshua stein ,
-.Mt jcs@jcs.org .
+.An joshua stein Aq Mt jcs@jcs.org .


### PR DESCRIPTION
commit message:
```
Fix the following `mandoc -Tlint -Wall` warnings:

  WARNING: lower case character in document title: Dt xbanish
  WARNING: missing -width in -tag list, using 8n: Bl -tag
  WARNING: cannot parse date, using it verbatim: $Mdocdate: July 21, 2014$

When $Mdocdate$ is used in .Dd, the comma is apparently supposed to be
ommitted, otherwise the output looks like this:

  OpenBSD 5.7                $Mdocdate: July 21, 2014$               OpenBSD 5.7
```

I changed the author format to match the examples in the mdoc(7) manual, but I'll drop that change if you'd like.