### PR TITLE
Makefile: only use DESTDIR in install rule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ CC	?= cc
 CFLAGS	?= -O2 -Wall -Wunused -Wmissing-prototypes -Wstrict-prototypes
 
 PREFIX	?= /usr/local
-BINDIR	?= $(DESTDIR)$(PREFIX)/bin
-MANDIR	?= $(DESTDIR)$(PREFIX)/man/man1
+BINDIR	?= $(PREFIX)/bin
+MANDIR	?= $(PREFIX)/man/man1
 
 INSTALL_PROGRAM ?= install -s
 INSTALL_DATA ?= install
@@ -29,10 +29,10 @@ $(OBJS): *.c
 	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 install: all
-	mkdir -p $(BINDIR)
-	$(INSTALL_PROGRAM) $(PROG) $(BINDIR)
-	mkdir -p $(MANDIR)
-	$(INSTALL_DATA) -m 644 xbanish.1 $(MANDIR)/xbanish.1
+	mkdir -p $(DESTDIR)$(BINDIR)
+	$(INSTALL_PROGRAM) $(PROG) $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(MANDIR)
+	$(INSTALL_DATA) -m 644 xbanish.1 $(DESTDIR)$(MANDIR)/xbanish.1
 
 clean:
 	rm -f $(PROG) $(OBJS)


### PR DESCRIPTION
DESTDIR should only override the overall root of the installation.
Remove $(DESTDIR) reference from definitions of BINDIR and MANDIR.
Prefix the references of BINDIR and MANDIR with DESTDIR in the
install rule. This way PREFIX, BINDIR, and MANDIR can all be set
independently without overriding the installation root of DESTDIR.