### PR TITLE
fix -i flag for xinput (non-legacy)

### DIFF
--- a/xbanish.c
+++ b/xbanish.c
@@ -130,11 +130,34 @@ main(int argc, char *argv[])
 
 		switch (etype) {
 		case KeyRelease:
-			if (ignored && (e.xkey.state & ignored)) {
-				if (debug)
-					printf("ignoring keystroke %d\n",
-					    e.xkey.keycode);
-				break;
+			if (ignored) {
+				unsigned int state = 0;
+
+				/* masks are only set on key release, if
+				 * ignore is set we must throw out non-release
+				 * events here */
+				if (e.type == key_press_type) {
+					break;
+				}
+
+				/* extract modifier state */
+				if (e.type == key_release_type) {
+					/* xinput device event */
+					XDeviceKeyEvent *key =
+					    (XDeviceKeyEvent *) &e;
+					state = key->state;
+				} else if (e.type == KeyRelease) {
+					/* legacy event */
+					state = e.xkey.state;
+				}
+
+				if (state & ignored) {
+					if (debug) {
+						printf("ignoring key %d\n",
+						    state);
+					}
+					break;
+				}
 			}
 
 			hide_cursor();


### PR DESCRIPTION
I installed the latest version of `xbanish` from git and noticed something very strange when running with even a single `-i` flag supplied.  `xbanish` would work normally as though no `-i` flags were supplied, until I moved my mouse AT ALL.  after that point, the cursor would *never* get hidden.  I did some investigating, and sure enough `e.xkey.keystate` was incorrectly being set to the X coordinate of my mouse!  I'm certain this was because of the nature of the `xkey` union.

With some more digging I found out that `xbanish` would work correctly when forced into legacy mode on my machine, but would fail with the xinput logic.  I've made it so the key state (which modifiers are held down) is correctly gathered for both xinput and legacy modes of operation.  I've been running this for a solid 24 hours now and it has been working flawlessly on my machine.

Thanks for the awesome project!