### PR TITLE
add -l for forced legacy mode

### DIFF
--- a/xbanish.1
+++ b/xbanish.1
@@ -40,6 +40,8 @@ Modifiers are:
 (Super, Windows, or Command), and
 .Ic mod5
 (ISO Level 3 Shift).
+.It Fl l
+Use legacy mode.
 .El
 .Sh SEE ALSO
 .Xr XFixes 3

--- a/xbanish.c
+++ b/xbanish.c
@@ -76,7 +76,7 @@ main(int argc, char *argv[])
 		{"mod4", Mod4Mask}, {"mod5", Mod5Mask}
 	};
 
-	while ((ch = getopt(argc, argv, "di:")) != -1)
+	while ((ch = getopt(argc, argv, "di:l")) != -1)
 		switch (ch) {
 		case 'd':
 			debug = 1;
@@ -87,6 +87,9 @@ main(int argc, char *argv[])
 				if (strcasecmp(optarg, mods[i].name) == 0)
 					ignored |= mods[i].mask;
 
+			break;
+		case 'l':
+			legacy = 1;
 			break;
 		default:
 			usage();
@@ -105,12 +108,17 @@ main(int argc, char *argv[])
 
 	XSetErrorHandler(swallow_error);
 
-	if (snoop_xinput(DefaultRootWindow(dpy)) == 0) {
+	if (!legacy && snoop_xinput(DefaultRootWindow(dpy)) == 0) {
 		if (debug)
 			warn("no XInput devices found, using legacy "
 			    "snooping");
 
 		legacy = 1;
+	}
+
+	if (legacy) {
+		if (debug)
+			printf("using legacy snooping\n");
 		snoop_legacy(DefaultRootWindow(dpy));
 	}
 
@@ -386,7 +394,7 @@ done:
 void
 usage(void)
 {
-	fprintf(stderr, "usage: %s [-d] [-i mod]\n", __progname);
+	fprintf(stderr, "usage: %s [-l] [-d] [-i mod]\n", __progname);
 	exit(1);
 }
 


### PR DESCRIPTION
I used a variation of this logic to test legacy mode when I made https://github.com/jcs/xbanish/pull/31.  I don't know if this option makes sense, since "legacy" may mean "deprecated" here in which case worrying about its support may not be necessary.

Either way, here's a flag to use legacy mode, and if it doesn't make sense to add it feel free to close this PR.