### PR TITLE
Enable permanent mouse pointer hiding until the xbanish process exits

### DIFF
--- a/xbanish.1
+++ b/xbanish.1
@@ -6,6 +6,7 @@
 .Nd hide the X11 mouse cursor when a key is pressed
 .Sh SYNOPSIS
 .Nm
+.Op Fl a
 .Op Fl d
 .Op Fl i Ar modifier
 .Sh DESCRIPTION
@@ -19,6 +20,8 @@ setting
 but the effect is global in the X11 session.
 .Sh OPTIONS
 .Bl -tag -width Ds
+.It Fl a
+Always hide mouse cursor.
 .It Fl d
 Print debugging messages to stdout.
 .It Fl i Ar modifier

--- a/xbanish.c
+++ b/xbanish.c
@@ -56,7 +56,7 @@ static int motion_type = -1;
 extern char *__progname;
 
 static Display *dpy;
-static int debug = 0, hiding = 0, legacy = 0;
+static int debug = 0, hiding = 0, legacy = 0, always_hide = 0;
 static unsigned char ignored;
 
 int
@@ -76,8 +76,11 @@ main(int argc, char *argv[])
 		{"mod4", Mod4Mask}, {"mod5", Mod5Mask}
 	};
 
-	while ((ch = getopt(argc, argv, "di:")) != -1)
+	while ((ch = getopt(argc, argv, "adi:")) != -1)
 		switch (ch) {
+		case 'a':
+			always_hide = 1;
+			break;
 		case 'd':
 			debug = 1;
 			break;
@@ -113,7 +116,11 @@ main(int argc, char *argv[])
 		legacy = 1;
 		snoop_legacy(DefaultRootWindow(dpy));
 	}
-
+   
+	if (always_hide) {
+		hide_cursor();
+	}
+   
 	for (;;) {
 		cookie = &e.xcookie;
 		XNextEvent(dpy, &e);
@@ -231,7 +238,11 @@ show_cursor(void)
 		printf("mouse moved, %sunhiding cursor\n",
 		    (hiding ? "" : "already "));
 
-	if (hiding) {
+	if (always_hide) {
+		return;
+	}
+   
+	if (hiding) { // disable cursor showing
 		XFixesShowCursor(dpy, DefaultRootWindow(dpy));
 		hiding = 0;
 	}
@@ -386,7 +397,7 @@ done:
 void
 usage(void)
 {
-	fprintf(stderr, "usage: %s [-d] [-i mod]\n", __progname);
+	fprintf(stderr, "usage: %s [-a] [-d] [-i mod]\n", __progname);
 	exit(1);
 }
 


### PR DESCRIPTION
Add a command line argument `-a` (for _always_) to hide mouse pointer while xbanish process runs, i.e. if `-a` is given then mouse pointer will be hidden on xbanish start and it will not be shown again