### PR TITLE
call XFreeDeviceList() after XListInputDevices()

### DIFF
--- a/xbanish.c
+++ b/xbanish.c
@@ -322,7 +322,7 @@ snoop_xinput(Window win)
 	int major, minor, rc, rawmotion = 0;
 	int ev = 0;
 	unsigned char mask[(XI_LASTEVENT + 7)/8];
-	XDeviceInfo *devinfo;
+	XDeviceInfo *devinfo = NULL;
 	XInputClassInfo *ici;
 	XDevice *device;
 	XIEventMask evmasks[1];
@@ -412,7 +412,8 @@ snoop_xinput(Window win)
 
 		if (XSelectExtensionEvent(dpy, win, event_list, ev)) {
 			warn("error selecting extension events");
-			return 0;
+			ev = 0;
+			goto done;
 		}
 	}
 
@@ -420,8 +421,13 @@ snoop_xinput(Window win)
 	DevicePresence(dpy, device_change_type, class_presence);
 	if (XSelectExtensionEvent(dpy, win, &class_presence, 1)) {
 		warn("error selecting extension events");
-		return 0;
+		ev = 0;
+		goto done;
 	}
+
+done:
+	if (devinfo != NULL)
+	   XFreeDeviceList(devinfo);
 
 	return ev;
 }


### PR DESCRIPTION
I currently keep my X session running for multiple days or weeks and this morning I found that xbanish used a whopping 2.8GB of memory.

I've looked at the code and found no call to `XFreeDeviceList()` after `XListInputDevices()`.
This could be the root cause, but I don't really know.  The free call should probably be added anyway ;-)

It seems that with commit 56971df21c4be32afc3b5206aa7fabc76dd98273 the call to `XListInputDevices()` has been moved inside a loop – before that, `XListInputDevices()` was only ever called once which did not stick out in the memory usage.