### PR TITLE
Add 'all' modifier to ignore all modifiers

### DIFF
--- a/xbanish.1
+++ b/xbanish.1
@@ -43,9 +43,11 @@ Modifiers are:
 .Ic mod3
 (Hyper),
 .Ic mod4
-(Super, Windows, or Command), and
+(Super, Windows, or Command),
 .Ic mod5
-(ISO Level 3 Shift).
+(ISO Level 3 Shift), and
+.Ic all
+(All of the above).
 .It Fl m Ar nw|ne|sw|se
 When hiding the mouse cursor, move it to this corner of the screen,
 then move it back when showing the cursor.

--- a/xbanish.c
+++ b/xbanish.c
@@ -85,7 +85,8 @@ main(int argc, char *argv[])
 		{"shift", ShiftMask}, {"lock", LockMask},
 		{"control", ControlMask}, {"mod1", Mod1Mask},
 		{"mod2", Mod2Mask}, {"mod3", Mod3Mask},
-		{"mod4", Mod4Mask}, {"mod5", Mod5Mask}
+		{"mod4", Mod4Mask}, {"mod5", Mod5Mask},
+		{"all", -1},
 	};
 
 	while ((ch = getopt(argc, argv, "adi:m:")) != -1)


### PR DESCRIPTION
This is useful, because instead of writing `-i shift -i lock -i control -i mod1 -i mod2 -i mod3 -i mod4 -i mod5`, one can now write `-i all`