### PR TITLE
add option to ignore scrolling

### DIFF
--- a/xbanish.1
+++ b/xbanish.1
@@ -11,6 +11,7 @@
 .Op Fl i Ar modifier
 .Op Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se
 .Op Fl t Ar seconds
+.Op Fl s
 .Sh DESCRIPTION
 .Nm
 hides the X11 mouse cursor when a key is pressed.
@@ -55,6 +56,8 @@ or current window, then move it back when showing the cursor.
 Hide the mouse cursor after
 .Ic seconds
 have passed without mouse movement.
+.It Fl s
+Ignore scrolling events.
 .El
 .Sh SEE ALSO
 .Xr XFixes 3

--- a/xbanish.c
+++ b/xbanish.c
@@ -49,7 +49,7 @@ static int device_change_type = -1;
 static long last_device_change = -1;
 
 static Display *dpy;
-static int hiding = 0, legacy = 0, always_hide = 0;
+static int hiding = 0, legacy = 0, always_hide = 0, ignore_scroll = 0;
 static unsigned timeout = 0;
 static unsigned char ignored;
 static XSyncCounter idler_counter = 0;
@@ -73,7 +73,7 @@ enum move_types {
 int
 main(int argc, char *argv[])
 {
-	int ch, i, ignore_scroll = 0;
+	int ch, i;
 	XEvent e;
 	XSyncAlarmNotifyEvent *alarm_e;
 	XGenericEventCookie *cookie;
@@ -256,7 +256,7 @@ main(int argc, char *argv[])
 			switch (xie->evtype) {
 			case XI_RawMotion:
 			case XI_RawButtonPress:
-				if (ignore_scroll && ((xie->detail > 3 && xie->detail < 8) ||
+				if (ignore_scroll && ((xie->detail >= 4 && xie->detail <= 7) ||
 						xie->event_x == xie->event_y))
 					break;
 				if (!always_hide)
@@ -579,7 +579,7 @@ void
 usage(char *progname)
 {
 	fprintf(stderr, "usage: %s [-a] [-d] [-i mod] [-m [w]nw|ne|sw|se] "
-	    "[-t seconds]\n", progname);
+	    "[-t seconds] [-s]\n", progname);
 	exit(1);
 }
 

--- a/xbanish.c
+++ b/xbanish.c
@@ -262,6 +262,7 @@ main(int argc, char *argv[])
 				if (!always_hide)
 					show_cursor();
 				break;
+
 			case XI_RawButtonRelease:
 				break;
 

--- a/xbanish.c
+++ b/xbanish.c
@@ -73,7 +73,7 @@ enum move_types {
 int
 main(int argc, char *argv[])
 {
-	int ch, i;
+	int ch, i, ignore_scroll = 0;
 	XEvent e;
 	XSyncAlarmNotifyEvent *alarm_e;
 	XGenericEventCookie *cookie;
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
 		{"all", -1},
 	};
 
-	while ((ch = getopt(argc, argv, "adi:m:t:")) != -1)
+	while ((ch = getopt(argc, argv, "adi:m:t:s")) != -1)
 		switch (ch) {
 		case 'a':
 			always_hide = 1;
@@ -131,6 +131,8 @@ main(int argc, char *argv[])
 			break;
 		case 't':
 			timeout = strtoul(optarg, NULL, 0);
+		case 's':
+			ignore_scroll = 1;
 			break;
 		default:
 			usage(argv[0]);
@@ -254,10 +256,12 @@ main(int argc, char *argv[])
 			switch (xie->evtype) {
 			case XI_RawMotion:
 			case XI_RawButtonPress:
+				if (ignore_scroll && ((xie->detail > 3 && xie->detail < 8) ||
+						xie->event_x == xie->event_y))
+					break;
 				if (!always_hide)
 					show_cursor();
 				break;
-
 			case XI_RawButtonRelease:
 				break;
 


### PR DESCRIPTION
another thing I had in my fork, might also want it upstreamed.
I had a worse workaround to deal with the mouse sending useless `RawMovement` codes on scrolling, but it turns out event_x and event_y are always equal on those so this works as well.