### PR TITLE
don't enable ignore_scroll on timeout

### DIFF
--- a/xbanish.c
+++ b/xbanish.c
@@ -130,6 +130,7 @@ main(int argc, char *argv[])
 			break;
 		case 't':
 			timeout = strtoul(optarg, NULL, 0);
+			break;
 		case 's':
 			ignore_scroll = 1;
 			break;


### PR DESCRIPTION
The manpage doesn't mention anything about timeout implicitly enabling ignore scroll. So I'm assuming this was unintentional.