### PR TITLE
allow setting custom move position

### DIFF
--- a/xbanish.1
+++ b/xbanish.1
@@ -9,7 +9,7 @@
 .Op Fl a
 .Op Fl d
 .Op Fl i Ar modifier
-.Op Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|+/\-xy
+.Op Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|\(+-x\(+-y
 .Op Fl t Ar seconds
 .Op Fl s
 .Sh DESCRIPTION
@@ -49,10 +49,12 @@ Modifiers are:
 .Ic mod5
 (ISO Level 3 Shift), and
 .Ic all
-.It Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|+/\-xy
+.It Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|\(+-x\(+-y
 When hiding the mouse cursor, move it to this corner of the screen
 or current window, then move it back when showing the cursor.
-Also accepts absolute positoning, see GEOMETRY SPECIFICATIONS of X(7).
+Also accepts absolute positioning, for example `+50-100' will be
+positioned 50 pixels from the left and 100 pixels from the bottom.
+See GEOMETRY SPECIFICATIONS of X(7) for more info.
 .It Fl t Ar seconds
 Hide the mouse cursor after
 .Ic seconds

--- a/xbanish.1
+++ b/xbanish.1
@@ -9,7 +9,7 @@
 .Op Fl a
 .Op Fl d
 .Op Fl i Ar modifier
-.Op Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se
+.Op Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|+/\-xy
 .Op Fl t Ar seconds
 .Op Fl s
 .Sh DESCRIPTION
@@ -49,9 +49,10 @@ Modifiers are:
 .Ic mod5
 (ISO Level 3 Shift), and
 .Ic all
-.It Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se
+.It Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|+/\-xy
 When hiding the mouse cursor, move it to this corner of the screen
 or current window, then move it back when showing the cursor.
+Also accepts absolute positoning, see GEOMETRY SPECIFICATIONS of X(7).
 .It Fl t Ar seconds
 Hide the mouse cursor after
 .Ic seconds
@@ -61,6 +62,7 @@ Ignore scrolling events.
 .El
 .Sh SEE ALSO
 .Xr XFixes 3
+.Xr X 7
 .Sh AUTHORS
 .Nm
 was written by


### PR DESCRIPTION
Main motivation for this was because moving the cursor to the `top-{right|left}` caused some issues with some GUI applications while the `bottom-{left,right}` area on my statusbar used to be clickable.

Due to that, I've been using a hardcoded patched version of xbanish which moves the cursor to bottom-mid instead; this patch is just a generalization of it. This would allow moving the cursor to bottom-mid by doing `-m x50y100` or top-mid by doing `-m x50y0` etc...

I can go ahead and update the usage and manpage if I get the green light.
