### PR TITLE
set_alarm: Misc fixes and improvements

### DIFF
--- a/xbanish.c
+++ b/xbanish.c
@@ -573,7 +573,8 @@ set_alarm(XSyncAlarm *alarm, XSyncTestType test)
 	    (unsigned long)(timeout * 1000) >> 32);
 	XSyncIntToValue(&attr.delta, 0);
 
-	flags = XSyncCACounter | XSyncCATestType | XSyncCAValue | XSyncCADelta;
+	flags = XSyncCACounter | XSyncCATestType | XSyncCAValueType |
+	    XSyncCAValue | XSyncCADelta;
 
 	if (*alarm)
 		XSyncDestroyAlarm(dpy, *alarm);

--- a/xbanish.c
+++ b/xbanish.c
@@ -564,10 +564,7 @@ void
 set_alarm(XSyncAlarm *alarm, XSyncTestType test)
 {
 	XSyncAlarmAttributes attr;
-	XSyncValue value;
 	unsigned int flags;
-
-	XSyncQueryCounter(dpy, idler_counter, &value);
 
 	attr.trigger.counter = idler_counter;
 	attr.trigger.test_type = test;

--- a/xbanish.c
+++ b/xbanish.c
@@ -569,8 +569,8 @@ set_alarm(XSyncAlarm *alarm, XSyncTestType test)
 	attr.trigger.counter = idler_counter;
 	attr.trigger.test_type = test;
 	attr.trigger.value_type = XSyncRelative;
-	XSyncIntsToValue(&attr.trigger.wait_value, timeout * 1000,
-	    (unsigned long)(timeout * 1000) >> 32);
+	XSyncIntsToValue(&attr.trigger.wait_value, timeout * 1000UL,
+	    (timeout * 1000UL) >> 32);
 	XSyncIntToValue(&attr.delta, 0);
 
 	flags = XSyncCACounter | XSyncCATestType | XSyncCAValueType |

--- a/xbanish.c
+++ b/xbanish.c
@@ -576,10 +576,10 @@ set_alarm(XSyncAlarm *alarm, XSyncTestType test)
 	flags = XSyncCACounter | XSyncCATestType | XSyncCAValueType |
 	    XSyncCAValue | XSyncCADelta;
 
-	if (*alarm)
-		XSyncDestroyAlarm(dpy, *alarm);
-
-	*alarm = XSyncCreateAlarm(dpy, flags, &attr);
+	if (*alarm == None)
+		*alarm = XSyncCreateAlarm(dpy, flags, &attr);
+	else
+		XSyncChangeAlarm(dpy, *alarm, flags, &attr);
 }
 
 void


### PR DESCRIPTION
I noticed a couple things going on in `set_alarm` which seemed dubious. Here's a summary of the changes (additional context provided in commit message). Feel free to cherry-pick in case you don't agree with a certain commit.

* `value` was unused, remove it.
* `value_type` was set in `attr` but the necessary value_mask wasn't set on `flags`. So add `XSyncCAValueType` to `flags`.
* Instead of destroying and creating alarm, just use XSyncChangeAlarm to change the existing alarm.
* Ensure multiplication takes place in `unsigned long` instead of casting the result (otherwise that expression would always result in 0).