### PR TITLE
feat: allow to specify master keyboard

### DIFF
--- a/xbanish.1
+++ b/xbanish.1
@@ -9,6 +9,7 @@
 .Op Fl a
 .Op Fl d
 .Op Fl i Ar modifier
+.Op Fl k Ar keyboard_prefix
 .Op Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|\(+-x\(+-y
 .Op Fl t Ar seconds
 .Op Fl s
@@ -49,6 +50,8 @@ Modifiers are:
 .Ic mod5
 (ISO Level 3 Shift), and
 .Ic all
+.It Fl k Ar keyboard_prefix
+When used, will only attach to the keyboards device that match the start of the argument. Useful when running kmonad or xremap.
 .It Fl m Oo Ar w Oc Ns Ar nw|ne|sw|se|\(+-x\(+-y
 When hiding the mouse cursor, move it to this corner of the screen
 or current window, then move it back when showing the cursor.

--- a/xbanish.c
+++ b/xbanish.c
@@ -111,10 +111,10 @@ main(int argc, char *argv[])
 					ignored |= mods[i].mask;
 
 			break;
-        case 'k':
-            // choose which keyboard device to listen only (in case of xremap or Kmonad being used)
-            master_keyboard_device = strdup(optarg);
-            break;
+		case 'k':
+			// choose which keyboard device to listen only (in case of xremap or Kmonad being used)
+			master_keyboard_device = optarg;
+			break;
 		case 'm':
 			if (strcmp(optarg, "nw") == 0)
 				move = MOVE_NW;
@@ -469,9 +469,9 @@ snoop_xinput(Window win)
 		ici++, j++) {
 			switch (ici->input_class) {
 			case KeyClass:
-                if (master_keyboard_device &&
-                    strncmp(master_keyboard_device, devinfo[i].name, strlen(master_keyboard_device)) != 0)
-                    continue;
+				if (master_keyboard_device &&
+					strncmp(master_keyboard_device, devinfo[i].name, strlen(master_keyboard_device)) != 0)
+					continue;
 
 				DPRINTF(("attaching to keyboard device %s "
 				    "(use %d)\n", devinfo[i].name,


### PR DESCRIPTION
The issue that I encountered was that after I setup [xremap](https://github.com/k0kubun/xremap), the cursor was flickering like in #78 and so I looked into this and realized that in that case, xbanish should only attach and listen to the new virtual keyboard created by xremap.

So this patch implement a new argument `-k` to specify which keyboard device name should the program attach to.

This implementation is basic and simple, I may forgot edge cases.