### PR TITLE
poll based timeout + handle SIGTERM for a clean exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MANDIR	?= $(PREFIX)/man/man1
 INSTALL_PROGRAM ?= install -s
 INSTALL_DATA ?= install
 
-LIBS	?= x11 xfixes xi xext
+LIBS	?= x11 xfixes xi
 INCLUDES?= `pkg-config --cflags $(LIBS)`
 LDFLAGS	+= `pkg-config --libs $(LIBS)`
 

--- a/xbanish.c
+++ b/xbanish.c
@@ -16,7 +16,10 @@
  */
 
 #include <err.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -38,6 +41,7 @@ void snoop_legacy(Window);
 void usage(char *);
 int swallow_error(Display *, XErrorEvent *);
 int parse_geometry(const char *s);
+void sighandler(int);
 
 /* xinput event type ids to be filled in later */
 static int button_press_type = -1;
@@ -53,6 +57,7 @@ static int hiding = 0, legacy = 0, always_hide = 0, ignore_scroll = 0;
 static time_t timeout = 0;
 static time_t timeout_at = 0;
 static unsigned char ignored;
+static int sigpipe[2];
 
 static int debug = 0;
 #define DPRINTF(x) { if (debug) { printf x; } };
@@ -143,6 +148,15 @@ main(int argc, char *argv[])
 	if (!(dpy = XOpenDisplay(NULL)))
 		errx(1, "can't open display %s", XDisplayName(NULL));
 
+	if (pipe(sigpipe) < 0)
+		err(1, "pipe");
+	if (fcntl(sigpipe[1], F_SETFD, O_NONBLOCK) < 0)
+		err(1, "fcntl");
+	struct sigaction sa = { .sa_handler = sighandler };
+	sigemptyset(&sa.sa_mask);
+	if (sigaction(SIGTERM, &sa, NULL) < 0)
+		err(1, "sigaction");
+
 #ifdef __OpenBSD__
 	if (pledge("stdio", NULL) == -1)
 		err(1, "pledge");
@@ -156,20 +170,29 @@ main(int argc, char *argv[])
 		hide_cursor();
 
 	for (;;) {
+		struct pollfd pfd[2] = {0};
 		int pending = XPending(dpy) > 0;
 		if (!pending) {
 			int poll_timeout = -1;
-			struct pollfd pfd;
-			pfd.fd = ConnectionNumber(dpy);
-			pfd.events = POLLIN;
+			pfd[0].fd = ConnectionNumber(dpy);
+			pfd[0].events = POLLIN;
+			pfd[1].fd = sigpipe[0];
+			pfd[1].events = POLLIN;
 			if (timeout && !hiding) {
 				poll_timeout = (timeout_at - time(NULL)) * 1000;
 				if (poll_timeout < 0)
 					poll_timeout = 0;
 			}
 			DPRINTF(("poll_timeout: %d\n", poll_timeout));
-			pending = poll(&pfd, 1, poll_timeout) > 0 &&
-				(pfd.revents & POLLIN);
+			pending = poll(pfd, 2, poll_timeout) > 0 &&
+				(pfd[0].revents & POLLIN);
+		}
+
+		if (pfd[1].revents & POLLIN) {
+			DPRINTF(("received signal, exiting...\n"));
+			if (hiding)
+				show_cursor();
+			break;
 		}
 
 		if (timeout && !hiding && time(NULL) >= timeout_at) {
@@ -285,6 +308,7 @@ main(int argc, char *argv[])
 			break;
 		}
 	}
+	XCloseDisplay(dpy);
 }
 
 void
@@ -586,4 +610,14 @@ parse_geometry(const char *s)
 		return 1;
 	}
 	return 0;
+}
+
+void
+sighandler(int signum)
+{
+	char dummy = 1;
+	int saved_errno = errno;
+	ssize_t res = write(sigpipe[1], &dummy, 1);
+	(void)res;
+	errno = saved_errno;
 }

--- a/xbanish.c
+++ b/xbanish.c
@@ -16,15 +16,15 @@
  */
 
 #include <err.h>
-#include <signal.h>
-#include <stdlib.h>
+#include <poll.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <X11/X.h>
 #include <X11/Xlib.h>
-#include <X11/extensions/sync.h>
 #include <X11/extensions/Xfixes.h>
 #include <X11/extensions/XInput.h>
 #include <X11/extensions/XInput2.h>
@@ -35,7 +35,6 @@ void show_cursor(void);
 void snoop_root(void);
 int snoop_xinput(Window);
 void snoop_legacy(Window);
-void set_alarm(XSyncAlarm *, XSyncTestType);
 void usage(char *);
 int swallow_error(Display *, XErrorEvent *);
 int parse_geometry(const char *s);
@@ -51,10 +50,9 @@ static long last_device_change = -1;
 
 static Display *dpy;
 static int hiding = 0, legacy = 0, always_hide = 0, ignore_scroll = 0;
-static unsigned timeout = 0;
+static time_t timeout = 0;
+static time_t timeout_at = 0;
 static unsigned char ignored;
-static XSyncCounter idler_counter = 0;
-static XSyncAlarm idle_alarm = None;
 
 static int debug = 0;
 #define DPRINTF(x) { if (debug) { printf x; } };
@@ -77,11 +75,7 @@ main(int argc, char *argv[])
 {
 	int ch, i;
 	XEvent e;
-	XSyncAlarmNotifyEvent *alarm_e;
 	XGenericEventCookie *cookie;
-	XSyncSystemCounter *counters;
-	int sync_event, error;
-	int major, minor, ncounters;
 
 	struct mod_lookup {
 		char *name;
@@ -161,27 +155,34 @@ main(int argc, char *argv[])
 	if (always_hide)
 		hide_cursor();
 
-	/* required setup for the xsync alarms used by timeout */
-	if (timeout) {
-		if (XSyncQueryExtension(dpy, &sync_event, &error) != True)
-			errx(1, "no sync extension available");
-
-		XSyncInitialize(dpy, &major, &minor);
-
-		counters = XSyncListSystemCounters(dpy, &ncounters);
-		for (i = 0; i < ncounters; i++) {
-			if (!strcmp(counters[i].name, "IDLETIME")) {
-				idler_counter = counters[i].counter;
-				break;
-			}
-		}
-		XSyncFreeSystemCounterList(counters);
-
-		if (!idler_counter)
-			errx(1, "no idle counter");
-	}
-
 	for (;;) {
+		int pending = XPending(dpy) > 0;
+		if (!pending) {
+			int poll_timeout = -1;
+			struct pollfd pfd;
+			pfd.fd = ConnectionNumber(dpy);
+			pfd.events = POLLIN;
+			if (timeout && !hiding) {
+				poll_timeout = (timeout_at - time(NULL)) * 1000;
+				if (poll_timeout < 0)
+					poll_timeout = 0;
+			}
+			DPRINTF(("poll_timeout: %d\n", poll_timeout));
+			pending = poll(&pfd, 1, poll_timeout) > 0 &&
+				(pfd.revents & POLLIN);
+		}
+
+		if (timeout && !hiding && time(NULL) >= timeout_at) {
+			DPRINTF(("timeout reached, hiding cursor\n"));
+			hide_cursor();
+			continue;
+		}
+
+		if (!pending) {
+			DPRINTF(("no xevent pending, continuing\n"));
+			continue;
+		}
+
 		cookie = &e.xcookie;
 		XNextEvent(dpy, &e);
 
@@ -280,19 +281,8 @@ main(int argc, char *argv[])
 			break;
 
 		default:
-			if (!timeout ||
-			    e.type != (sync_event + XSyncAlarmNotify)) {
-				DPRINTF(("unknown event type %d\n", e.type));
-				break;
-			}
-
-			alarm_e = (XSyncAlarmNotifyEvent *)&e;
-			if (alarm_e->alarm == idle_alarm) {
-				DPRINTF(("idle counter reached %dms, hiding "
-				    "cursor\n",
-				    XSyncValueLow32(alarm_e->counter_value)));
-				hide_cursor();
-			}
+			DPRINTF(("unknown event type %d\n", e.type));
+			break;
 		}
 	}
 }
@@ -380,8 +370,8 @@ show_cursor(void)
 	    (hiding ? "" : "already ")));
 
 	if (timeout) {
-		DPRINTF(("(re)setting timeout of %us\n", timeout));
-		set_alarm(&idle_alarm, XSyncPositiveComparison);
+		DPRINTF(("(re)setting timeout of %llds\n", (long long)timeout));
+		timeout_at = time(NULL) + timeout;
 	}
 
 	if (!hiding)
@@ -558,30 +548,6 @@ snoop_legacy(Window win)
 done:
 	if (kids != NULL)
 		XFree(kids); /* hide yo kids */
-}
-
-void
-set_alarm(XSyncAlarm *alarm, XSyncTestType test)
-{
-	XSyncAlarmAttributes attr;
-	XSyncValue value;
-	unsigned int flags;
-
-	XSyncQueryCounter(dpy, idler_counter, &value);
-
-	attr.trigger.counter = idler_counter;
-	attr.trigger.test_type = test;
-	attr.trigger.value_type = XSyncRelative;
-	XSyncIntsToValue(&attr.trigger.wait_value, timeout * 1000,
-	    (unsigned long)(timeout * 1000) >> 32);
-	XSyncIntToValue(&attr.delta, 0);
-
-	flags = XSyncCACounter | XSyncCATestType | XSyncCAValue | XSyncCADelta;
-
-	if (*alarm)
-		XSyncDestroyAlarm(dpy, *alarm);
-
-	*alarm = XSyncCreateAlarm(dpy, flags, &attr);
 }
 
 void


### PR DESCRIPTION
### use poll based event loop for timeout

simpler this way and avoids dependency on Xext

### handle SIGTERM for a clean exit

currently there's no way to perform a clean exit. terminating
the process via signal while the mouse is hidden sometimes
leaves the mouse in a hidden state.
